### PR TITLE
Add note to build guide to flash blackpill before soldering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To build the keyboard, you'll also need a soldering iron and some tin. Follow th
 
 ### Firmware
 
-The Cantor keyboard uses the QMK firmware. Firmware for this keyboard is comming soon to the main QMK repository with [this PR](https://github.com/qmk/qmk_firmware/pull/16552).
+The Cantor keyboard uses the QMK firmware. Firmware for this keyboard is coming soon to the main QMK repository with [this PR](https://github.com/qmk/qmk_firmware/pull/16552).
 
 To flash the firmware to the microcontroller connect the blackpill to your computer and set it to bootloader mode. To do this the first time:
 

--- a/doc/build_guide.md
+++ b/doc/build_guide.md
@@ -1,6 +1,10 @@
 # Build Guide
 
-1. Solder the pin headers to the blackpill microcontrollers. The microcontroller must be face down, as shown. ![blackpill with pin headers](assets/blackpill_pin_headers.jpg)
+1. Solder the pin headers to the blackpill microcontrollers. The microcontroller must be face down, as shown.
+
+   ![blackpill with pin headers](assets/blackpill_pin_headers.jpg)
+
+Optionally, flash the firmware onto the microcontroller to ensure it is not defective.
 
 2. Solder the blackpill sockets and TRRS jacks on both PCBs, as shown. Sockets must be placed on top of the white PCB markings. Also, make sure you solder the components on different sides of the PCBs, so you end up with a right and left side and not two sides of the same hand.
 
@@ -10,8 +14,8 @@
 
    ![switches](assets/switches.jpg)
 
-   4. Place the rubber feet on the bottom of the PCB.
+4. Place the rubber feet on the bottom of the PCB.
 
-      ![rubber feet](assets/rubber_feet.jpg)
+   ![rubber feet](assets/rubber_feet.jpg)
 
 5. Place the keycaps on top of the switches. Congrats! Your keyboard is built!


### PR DESCRIPTION
I had a defective blackpill which threw errors upon flashing with QMK. 
Thankfully, I hadn't soldered it to the PCB yet, and had a spare. 
This adds a suggestion to the build guide to flash before soldering. 